### PR TITLE
Add action to disallow merge commits inside PR branch

### DIFF
--- a/.github/workflows/check-merge-commits.yml
+++ b/.github/workflows/check-merge-commits.yml
@@ -1,0 +1,22 @@
+name: "CI"
+on:
+  pull_request:
+
+jobs:
+  check-merge-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check if there are merge commits
+        run: |
+          commits="$(git rev-list --merges origin/main..${{github.event.pull_request.head.sha}})"
+          if [ -n "$commits" ]; then
+            echo ""
+            echo "==========="
+            echo ""
+            echo "Esse PR contém commits de merge. Remova-os para poder mergear:"
+            echo "$commits"
+            exit 1
+          fi


### PR DESCRIPTION
This will ensure that PRs with merge commits (e.g. updated by merge) can't be merged. This ensures the branches are only updated through rebase, and finally clean-merged with a merge commit.