### PR TITLE
refactor(site/members/luana): simplify CSS and make it more consistent

### DIFF
--- a/site/src/_members/luana.mkdn
+++ b/site/src/_members/luana.mkdn
@@ -20,15 +20,11 @@ gay_colors:
     - "#a30262"
 extra_css: |
     :root {
-        --background-color: black;
+        --color-bg: black;
         --color-text: DarkSeaGreen;
-        --link-color: pink;
-        --color-bg-alt: #34343d;
-    }
-
-    body {
-        background-color: var(--background-color);
-        color: var(--color-text);
+        --color-fade: SkyBlue;
+        --color-blossom: pink;
+        --color-bg-alt: #333;
     }
 
     #rotating {
@@ -71,14 +67,6 @@ extra_css: |
         100% {
             color: red;
         }
-    }
-
-    header, nav, footer {
-        color: var(--text-color);
-    }
-
-    a {
-        color: var(--link-color);
     }
 ---
 


### PR DESCRIPTION
Como o pessoal está usando de exemplo, fiz um pequeno refactor para simplificar o seu CSS. Essa mudança também deixa ele mais consistente, por exemplo, acertando a cor dos `<hr>` e `<blockquote>` pra combinar.

Estou setando explicitamente o --color-fade pra skyblue, que é a cor que o seu está hoje no site em prod. 

Antes:
![image](https://github.com/user-attachments/assets/f70f9056-76dc-4ef9-a78a-523db7ab5ee8)

Depois:
![image](https://github.com/user-attachments/assets/7a0a3132-da1e-407d-acd5-7568377bf6a7)
