### PR TITLE
CI: run nothing-but-nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v25
+      - uses: wimpysworld/nothing-but-nix@bfeb418c0047173b701321078aca83b342e77ec2
+      - uses: cachix/install-nix-action@v31
       - id: set-matrix
         name: Generate Nix Matrix
         run: |
@@ -28,7 +29,8 @@ jobs:
       matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v25
+      - uses: wimpysworld/nothing-but-nix@bfeb418c0047173b701321078aca83b342e77ec2
+      - uses: cachix/install-nix-action@v31
       - uses: cachix/cachix-action@v14
         with:
           name: gelos-icmc

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,8 @@ jobs:
       name: Prod
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v25
+      - uses: wimpysworld/nothing-but-nix@bfeb418c0047173b701321078aca83b342e77ec2
+      - uses: cachix/install-nix-action@v31
       - uses: cachix/cachix-action@v14
         with:
           name: gelos-icmc


### PR DESCRIPTION
This purges the github action runner, so that there's enough disk space for larger builds.